### PR TITLE
Strengthen offer parsing and conditions fallback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -261,7 +261,7 @@ def _looks_like_search(text: str) -> bool:
 def _normalize_conditions(offer: dict, fallback_text: str) -> dict:
     """
     Гарантируем, что у оффера есть поле conditions со строкой.
-    Если conditions пусты — кладём туда исходный текст.
+    Если conditions пусты или состоят из пробелов — кладём туда исходный текст.
     """
     if not isinstance(offer, dict):
         offer = {}
@@ -273,6 +273,8 @@ def _normalize_conditions(offer: dict, fallback_text: str) -> dict:
         offer["conditions"] = fallback_text
     elif not isinstance(conditions, str):
         offer["conditions"] = str(conditions)
+    elif not conditions.strip():
+        offer["conditions"] = fallback_text
 
     return offer
 


### PR DESCRIPTION
## Summary
- add keyword heuristic to hint offer vs search classification before sending to OpenAI
- tighten parsing prompt, force deterministic sampling, and require unparsed details to land in conditions
- ensure offers always retain original text in conditions when the model leaves the field empty

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693335661e908320aed4c2d3e029b533)