### PR TITLE
Use latest OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    ```env
    BOT_TOKEN=...
    OPENAI_API_KEY=...
-   OPENAI_MODEL=gpt-4o-mini
+   OPENAI_MODEL=gpt-4.1
    DB_PATH=offers.db
    LOG_LEVEL=INFO
    ```

--- a/src/config.py
+++ b/src/config.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 class Settings:
     bot_token: str
     openai_api_key: str
-    openai_model: str = "gpt-4o-mini"
+    openai_model: str = "gpt-4.1"
     db_path: str = "offers.db"
     log_level: str = "INFO"
 


### PR DESCRIPTION
## Summary
- switch default OpenAI model configuration to gpt-4.1
- update README example environment variable to match new default

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69334e4766988320a71e53d28d9485d4)